### PR TITLE
Add `<Textfield />` Playground component

### DIFF
--- a/src/design-system/inputs/Textfield/Playground/data.ts
+++ b/src/design-system/inputs/Textfield/Playground/data.ts
@@ -1,0 +1,71 @@
+import { IOptions } from "./type";
+
+const statusOptions = ["pending", "invalid", "valid"] as const;
+
+const typeOptions = [
+  "text",
+  "password",
+  "email",
+  "number",
+  "search",
+  "tel",
+] as const;
+
+export const options: IOptions[] = [
+  {
+    nameProps: "id",
+    typeControl: "Textfield",
+  },
+  {
+    nameProps: "name",
+    typeControl: "Textfield",
+  },
+
+  {
+    nameProps: "placeholder",
+    typeControl: "Textfield",
+  },
+  {
+    nameProps: "type",
+    typeControl: "Select",
+    option: typeOptions.map((item) => ({
+      id: item,
+      label: item,
+      disabled: false,
+    })),
+  },
+  {
+    nameProps: "label",
+    typeControl: "Textfield",
+  },
+  {
+    nameProps: "value",
+    typeControl: "Textfield",
+  },
+  {
+    nameProps: "status",
+    typeControl: "Select",
+    option: statusOptions.map((item) => ({
+      id: item,
+      label: item,
+      disabled: false,
+    })),
+  },
+
+  {
+    nameProps: "fullwidth",
+    typeControl: "Switch",
+  },
+  {
+    nameProps: "disabled",
+    typeControl: "Switch",
+  },
+  {
+    nameProps: "required",
+    typeControl: "Switch",
+  },
+  {
+    nameProps: "readonly",
+    typeControl: "Switch",
+  },
+];

--- a/src/design-system/inputs/Textfield/Playground/index.tsx
+++ b/src/design-system/inputs/Textfield/Playground/index.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { darcula } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+import { Stack, Textfield } from "@inube/design-system";
+
+import { ControlsProps } from "@components/feedback/ControlsPlayground";
+import { IvaluesProps } from "@components/feedback/ControlsPlayground/types";
+
+import { IselectProps, ItextfieldProps, IswitchChecked } from "./type";
+import { options } from "./data";
+
+export const PlaygroundTextfield = () => {
+  const [dataChildren, setDataChildren] = useState<
+    IvaluesProps<IselectProps, ItextfieldProps, IswitchChecked>
+  >({
+    selectProps: {
+      type: "text",
+      status: "pending",
+      size: "compact",
+    },
+    textfieldProps: {
+      id: "id",
+      label: "label",
+      name: "name",
+      placeholder: "placeholder",
+      value: "",
+    },
+    switchChecked: {
+      fullwidth: false,
+      disabled: false,
+      required: false,
+      readOnly: false,
+    },
+  });
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDataChildren({
+      ...dataChildren,
+      textfieldProps: {
+        ...dataChildren.textfieldProps,
+        value: e.target.value,
+      },
+    });
+  };
+
+  const handleChildData = (
+    data: IvaluesProps<IselectProps, ItextfieldProps, IswitchChecked>,
+  ) => {
+    setDataChildren(data);
+  };
+
+  return (
+    <Stack direction="column" margin="s400">
+      <Stack>
+        <Textfield
+          id={dataChildren?.textfieldProps?.id}
+          label={dataChildren?.textfieldProps?.label}
+          name={dataChildren?.textfieldProps?.name}
+          placeholder={dataChildren?.textfieldProps?.placeholder}
+          value={dataChildren?.textfieldProps?.value}
+          type={dataChildren?.selectProps?.type}
+          status={dataChildren?.selectProps?.status}
+          size={dataChildren?.selectProps?.size}
+          fullwidth={dataChildren?.switchChecked?.fullwidth}
+          disabled={dataChildren?.switchChecked?.disabled}
+          required={dataChildren?.switchChecked?.required}
+          readOnly={dataChildren?.switchChecked?.readOnly}
+          onChange={onChange}
+        />
+      </Stack>
+
+      <SyntaxHighlighter
+        language="tsx"
+        style={darcula}
+        customStyle={{ borderRadius: "10px" }}
+        showLineNumbers
+      >
+        {`import { Icon } from "@inube/design-system";
+
+export const ComponentIcon = () => <Textfield ${
+          dataChildren?.textfieldProps?.id &&
+          `id="${dataChildren?.textfieldProps?.id}"`
+        } ${
+          dataChildren?.textfieldProps?.name &&
+          `name="${dataChildren?.textfieldProps?.name}"`
+        } ${
+          dataChildren?.textfieldProps?.label &&
+          `label="${dataChildren?.textfieldProps?.label}"`
+        } ${
+          dataChildren?.textfieldProps?.placeholder &&
+          `placeholder="${dataChildren?.textfieldProps?.placeholder}"`
+        } ${
+          dataChildren?.selectProps?.type &&
+          `type="${dataChildren?.selectProps?.type}"`
+        } ${
+          dataChildren?.selectProps?.status &&
+          `status="${dataChildren?.selectProps?.status}"`
+        } ${
+          dataChildren?.selectProps?.size &&
+          `size="${dataChildren?.selectProps?.size}"`
+        } ${dataChildren?.switchChecked?.fullwidth ? "fullwidth" : ""} ${
+          dataChildren?.switchChecked?.disabled ? "disabled" : ""
+        } ${dataChildren?.switchChecked?.readOnly ? "readOnly" : ""} ${
+          dataChildren?.switchChecked?.readOnly ? "required" : ""
+        }  />;`}
+      </SyntaxHighlighter>
+
+      <ControlsProps
+        options={options}
+        sendFatherData={handleChildData}
+        valuesProps={dataChildren}
+      />
+    </Stack>
+  );
+};

--- a/src/design-system/inputs/Textfield/Playground/type.ts
+++ b/src/design-system/inputs/Textfield/Playground/type.ts
@@ -1,0 +1,33 @@
+interface IOption {
+  id: string;
+  label: string;
+  disabled: boolean;
+}
+
+export interface IOptions {
+  nameProps: string;
+  typeControl: "Select" | "Textfield" | "Switch";
+  option?: IOption[];
+}
+
+//type typeKeySelect = "type" | "status";
+
+export interface IselectProps {
+  type: string;
+  status: string;
+}
+
+export interface ItextfieldProps {
+  id: string;
+  label: string;
+  name: string;
+  placeholder: string;
+  value: string;
+}
+
+export interface IswitchChecked {
+  fullwidth: boolean;
+  disabled: boolean;
+  required: boolean;
+  readOnly: boolean;
+}

--- a/src/pages/components/inputs/Textfield/index.tsx
+++ b/src/pages/components/inputs/Textfield/index.tsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 
 import { Stack, Tabs } from "@inube/design-system";
 import { PageCodeTextfield } from "@design-system/inputs/Textfield/code";
+import { PlaygroundTextfield } from "@design-system/inputs/Textfield/Playground";
 
 const tabs = [
   {
-    id: "Example",
-    label: "Example",
+    id: "Playground",
+    label: "Playground",
     isDisabled: false,
   },
   {
@@ -27,7 +28,7 @@ export const PageTextfield = () => {
       <Stack margin="s200 s400">
         <Tabs onChange={handleTabChange} tabs={tabs} selectedTab={activeTab} />
       </Stack>
-      {/*activeTab === "Example" && < /> */}
+      {activeTab === "Playground" && <PlaygroundTextfield />}
       {activeTab === "Code" && <PageCodeTextfield />}
     </>
   );


### PR DESCRIPTION
Add the **Playground** with its props controls handling functionality, for the documentation of the `<Textfield />` component.