### PR TITLE
Refactor the typing of the `<ControlsPlayground />` component

### DIFF
--- a/src/components/feedback/ControlsPlayground/index.tsx
+++ b/src/components/feedback/ControlsPlayground/index.tsx
@@ -123,7 +123,9 @@ export const ControlsProps = <S = undefined, T = undefined, W = undefined>(
                   fullwidth
                   options={option.option}
                   onChange={handleOnChangeSelect}
-                  value={controlsData?.selectProps?.[option.nameProps]}
+                  value={
+                    controlsData?.selectProps?.[option.nameProps as keyof S]
+                  }
                 />
               )}
               {option.typeControl === "Textfield" && (
@@ -132,7 +134,9 @@ export const ControlsProps = <S = undefined, T = undefined, W = undefined>(
                   name={option.nameProps}
                   fullwidth
                   onChange={handleOnChangeTextfield}
-                  value={controlsData?.textfieldProps?.[option.nameProps]}
+                  value={
+                    controlsData?.textfieldProps?.[option.nameProps as keyof T]
+                  }
                 />
               )}
               {option.typeControl === "Switch" && (
@@ -140,7 +144,9 @@ export const ControlsProps = <S = undefined, T = undefined, W = undefined>(
                   id={option.nameProps}
                   name={option.nameProps}
                   size="large"
-                  checked={controlsData?.switchChecked?.[option.nameProps]}
+                  checked={
+                    controlsData?.switchChecked?.[option.nameProps as keyof W]
+                  }
                   onChange={handleOnChangeSwitch}
                 />
               )}

--- a/src/components/feedback/ControlsPlayground/types.ts
+++ b/src/components/feedback/ControlsPlayground/types.ts
@@ -1,5 +1,5 @@
-export interface IvaluesProps<S = undefined, T = undefined, W = undefined> {
-  selectProps?: { [key: string]: string | S };
-  textfieldProps?: { [key: string]: string | T };
-  switchChecked?: { [key: string]: boolean | W };
+export interface IvaluesProps<S = unknown, T = unknown, W = unknown> {
+  selectProps?: S;
+  textfieldProps?: T;
+  switchChecked?: W;
 }

--- a/src/design-system/data/User/Playground/types.ts
+++ b/src/design-system/data/User/Playground/types.ts
@@ -9,13 +9,12 @@ interface IOption {
   disabled: boolean;
 }
 export const sizeOption: readonly string[] = ["large", "small"];
+
 export interface ItextfieldProps {
-  id: string;
-  userName: string;
-  client: string;
-  [key: string]: string;
+  id?: string;
+  userName?: string;
+  client?: string;
 }
 export interface IselectProps {
   size: (typeof sizeOption)[number];
-  [key: string]: string;
 }

--- a/src/design-system/inputs/Button/Playground/type.ts
+++ b/src/design-system/inputs/Button/Playground/type.ts
@@ -17,29 +17,23 @@ export const spacingOptions = ["wide", "compact"] as const;
 export const variantOptions = ["filled", "outline", "none"] as const;
 
 export interface IselectProps {
-  [key: string]: {
-    appearance: (typeof appearanceOptions)[number];
-    type: (typeof typeButton)[number];
-    spacing: (typeof spacingOptions)[number];
-    variant: (typeof variantOptions)[number];
-  };
+  appearance: (typeof appearanceOptions)[number];
+  type: (typeof typeButton)[number];
+  spacing: (typeof spacingOptions)[number];
+  variant: (typeof variantOptions)[number];
 }
 
 export interface ItextfielProps {
-  [key: string]: {
-    children: string;
-    path: string;
-  };
+  children: string;
+  path: string;
 }
 
 export interface IswitchProps {
-  [key: string]: {
-    loading: boolean;
-    disabled: boolean;
-    fullwidth: boolean;
-    cursorHover: boolean;
-    parentHover: boolean;
-  };
+  loading: boolean;
+  disabled: boolean;
+  fullwidth: boolean;
+  cursorHover: boolean;
+  parentHover: boolean;
 }
 
 interface IOption {

--- a/src/design-system/inputs/Textarea/Playground/index.tsx
+++ b/src/design-system/inputs/Textarea/Playground/index.tsx
@@ -23,7 +23,6 @@ export const PlaygroundTextarea = () => {
       label: "label",
       placeholder: "placeholder",
       value: "",
-
       lengthThreshold: "10",
       maxLength: "200",
     },
@@ -64,7 +63,7 @@ export const PlaygroundTextarea = () => {
           required={dataChildren?.switchChecked?.required}
           readonly={dataChildren?.switchChecked?.readonly}
           value={dataChildren?.textfieldProps?.value}
-          status={dataChildren?.textfieldProps?.status}
+          status={dataChildren?.selectProps?.status}
           lengthThreshold={dataChildren?.textfieldProps?.lengthThreshold}
           maxLength={dataChildren?.textfieldProps?.maxLength}
           onChange={onChange}

--- a/src/design-system/inputs/Textarea/Playground/types.ts
+++ b/src/design-system/inputs/Textarea/Playground/types.ts
@@ -15,12 +15,13 @@ export interface IselectProps {
 }
 
 export interface ItextfielProps {
-  id: string;
-  label: string;
-  name: string;
-  placeholder: string;
-  value: string;
-  lengthThreshold: string;
+  id?: string;
+  label?: string;
+  name?: string;
+  placeholder?: string;
+  value?: string;
+  maxLength?: string;
+  lengthThreshold?: string;
 }
 
 export interface IswitchProps {

--- a/src/design-system/inputs/Textfield/Playground/type.ts
+++ b/src/design-system/inputs/Textfield/Playground/type.ts
@@ -15,13 +15,14 @@ export interface IOptions {
 export interface IselectProps {
   type: string;
   status: string;
+  size: string;
 }
 
 export interface ItextfieldProps {
-  id: string;
-  label: string;
-  name: string;
-  placeholder: string;
+  id?: string;
+  label?: string;
+  name?: string;
+  placeholder?: string;
   value: string;
 }
 


### PR DESCRIPTION
Refactor the typing implemented in the <ControlsPlayground/> component, since currently, the implementation of the logic in the generics validate correctly the generics passed, for the implementation of the props controls.