### PR TITLE
Add content to Playground tab for `<Breadcrumbs />`

### DIFF
--- a/src/design-system/navigation/Breadcrumbs/Playground/data.ts
+++ b/src/design-system/navigation/Breadcrumbs/Playground/data.ts
@@ -1,3 +1,13 @@
-import { IOptions } from "./type";
+import { IOptions, optionsValue } from "./type";
 
-export const options: IOptions[] = [];
+export const options: IOptions[] = [
+  {
+    nameProps: "options",
+    typeControl: "Select",
+    option: optionsValue.map((optionsValue) => ({
+      id: optionsValue,
+      label: optionsValue,
+      disabled: false,
+    })),
+  },
+];

--- a/src/design-system/navigation/Breadcrumbs/Playground/data.ts
+++ b/src/design-system/navigation/Breadcrumbs/Playground/data.ts
@@ -1,0 +1,3 @@
+import { IOptions } from "./type";
+
+export const options: IOptions[] = [];

--- a/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
+++ b/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
@@ -17,13 +17,16 @@ export const PlaygroundBreadcrumbs = () => {
       options: "3",
     },
   });
+
   const handleChildData = (data: IvaluesProps<IselectProps>) => {
     setDataChildren(data);
   };
+
   const spliceCrumbs = crumbs.splice(
     0,
     parseInt(dataChildren!.selectProps!.options)
   );
+
   return (
     <Stack direction="column" gap="20px" margin="s400">
       <Stack direction="column" width="800px">

--- a/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
+++ b/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
@@ -1,44 +1,33 @@
+import { useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { darcula } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
 import { Stack, Breadcrumbs } from "@inube/design-system";
 
-/* import { ControlsProps } from "@components/feedback/ControlsPlayground";
+import { ControlsProps } from "@components/feedback/ControlsPlayground";
 import { IvaluesProps } from "@components/feedback/ControlsPlayground/types";
-import { options } from "./data"; */
+
+import { options } from "./data";
+import { IselectProps } from "./type";
+import { crumbs } from "./mucks";
 
 export const PlaygroundBreadcrumbs = () => {
+  const [dataChildren, setDataChildren] = useState<IvaluesProps<IselectProps>>({
+    selectProps: {
+      options: "3",
+    },
+  });
+  const handleChildData = (data: IvaluesProps<IselectProps>) => {
+    setDataChildren(data);
+  };
+  const spliceCrumbs = crumbs.splice(
+    0,
+    parseInt(dataChildren!.selectProps!.options)
+  );
   return (
     <Stack direction="column" gap="20px" margin="s400">
-      <Stack>
-        <Breadcrumbs
-          crumbs={[
-            {
-              label: "Inicio",
-              href: "#",
-            },
-            {
-              label: "Usuarios",
-              href: "#",
-            },
-            {
-              label: "Invitacion",
-              href: "#",
-            },
-            {
-              label: "Edicion",
-              href: "#",
-            },
-            {
-              label: "Ramas",
-              href: "#",
-            },
-            {
-              label: "Ciudad",
-              href: "#",
-            },
-          ]}
-        />
+      <Stack direction="column" width="800px">
+        <Breadcrumbs crumbs={spliceCrumbs} />
       </Stack>
 
       <SyntaxHighlighter language="javascript" style={darcula} showLineNumbers>
@@ -46,6 +35,11 @@ export const PlaygroundBreadcrumbs = () => {
         
 export const ComponentBreadcrumbs = () => <Breadcrumbs />`}
       </SyntaxHighlighter>
+      <ControlsProps
+        options={options}
+        sendFatherData={handleChildData}
+        valuesProps={dataChildren}
+      />
     </Stack>
   );
 };

--- a/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
+++ b/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
@@ -1,0 +1,51 @@
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { darcula } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+import { Stack, Breadcrumbs } from "@inube/design-system";
+
+/* import { ControlsProps } from "@components/feedback/ControlsPlayground";
+import { IvaluesProps } from "@components/feedback/ControlsPlayground/types";
+import { options } from "./data"; */
+
+export const PlaygroundBreadcrumbs = () => {
+  return (
+    <Stack direction="column" gap="20px" margin="s400">
+      <Stack>
+        <Breadcrumbs
+          crumbs={[
+            {
+              label: "Inicio",
+              href: "#",
+            },
+            {
+              label: "Usuarios",
+              href: "#",
+            },
+            {
+              label: "Invitacion",
+              href: "#",
+            },
+            {
+              label: "Edicion",
+              href: "#",
+            },
+            {
+              label: "Ramas",
+              href: "#",
+            },
+            {
+              label: "Ciudad",
+              href: "#",
+            },
+          ]}
+        />
+      </Stack>
+
+      <SyntaxHighlighter language="javascript" style={darcula} showLineNumbers>
+        {`import { Breadcrumbs } from "@inube/design-system";
+        
+export const ComponentBreadcrumbs = () => <Breadcrumbs />`}
+      </SyntaxHighlighter>
+    </Stack>
+  );
+};

--- a/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
+++ b/src/design-system/navigation/Breadcrumbs/Playground/index.tsx
@@ -14,7 +14,7 @@ import { crumbs } from "./mucks";
 export const PlaygroundBreadcrumbs = () => {
   const [dataChildren, setDataChildren] = useState<IvaluesProps<IselectProps>>({
     selectProps: {
-      options: "3",
+      options: "5",
     },
   });
 
@@ -22,7 +22,7 @@ export const PlaygroundBreadcrumbs = () => {
     setDataChildren(data);
   };
 
-  const spliceCrumbs = crumbs.splice(
+  const sliceCrumbs = crumbs.slice(
     0,
     parseInt(dataChildren!.selectProps!.options)
   );
@@ -30,7 +30,7 @@ export const PlaygroundBreadcrumbs = () => {
   return (
     <Stack direction="column" gap="20px" margin="s400">
       <Stack direction="column" width="800px">
-        <Breadcrumbs crumbs={spliceCrumbs} />
+        <Breadcrumbs crumbs={sliceCrumbs} />
       </Stack>
 
       <SyntaxHighlighter language="javascript" style={darcula} showLineNumbers>

--- a/src/design-system/navigation/Breadcrumbs/Playground/mucks.ts
+++ b/src/design-system/navigation/Breadcrumbs/Playground/mucks.ts
@@ -1,0 +1,38 @@
+export const crumbs = [
+  {
+    id: "1",
+    label: "Inicio",
+    path: "/inicio",
+    isActive: true,
+  },
+  {
+    id: "2",
+    label: "Usuarios",
+    path: "/usuarios",
+    isActive: true,
+  },
+  {
+    id: "3",
+    label: "Invitacion",
+    path: "/invitacion",
+    isActive: true,
+  },
+  {
+    id: "4",
+    label: "Edicion",
+    path: "/edicion",
+    isActive: false,
+  },
+  {
+    id: "5",
+    label: "ciudad",
+    path: "/ciudad",
+    isActive: false,
+  },
+  {
+    id: "6",
+    label: "Ramas",
+    path: "/ramas",
+    isActive: false,
+  },
+];

--- a/src/design-system/navigation/Breadcrumbs/Playground/type.ts
+++ b/src/design-system/navigation/Breadcrumbs/Playground/type.ts
@@ -1,3 +1,5 @@
+export const optionsValue: readonly string[] = ["1", "2", "3", "4", "5", "6"];
+
 interface IOption {
   id: string;
   label: string;
@@ -8,4 +10,8 @@ export interface IOptions {
   nameProps: string;
   typeControl: "Select" | "Textfield" | "Switch";
   option?: IOption[];
+}
+
+export interface IselectProps {
+  options: (typeof optionsValue)[number];
 }

--- a/src/design-system/navigation/Breadcrumbs/Playground/type.ts
+++ b/src/design-system/navigation/Breadcrumbs/Playground/type.ts
@@ -1,0 +1,11 @@
+interface IOption {
+  id: string;
+  label: string;
+  disabled: boolean;
+}
+
+export interface IOptions {
+  nameProps: string;
+  typeControl: "Select" | "Textfield" | "Switch";
+  option?: IOption[];
+}

--- a/src/pages/components/navigation/Breadcrumbs/index.tsx
+++ b/src/pages/components/navigation/Breadcrumbs/index.tsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 
 import { Stack, Tabs } from "@inube/design-system";
 import { CodeBreadcrumbs } from "@design-system/navigation/Breadcrumbs/code";
+import { PlaygroundBreadcrumbs } from "@design-system/navigation/Breadcrumbs/Playground";
 
 const tabs = [
   {
-    id: "Example",
-    label: "Example",
+    id: "Playground",
+    label: "Playground",
     isDisabled: false,
   },
   {
@@ -27,7 +28,7 @@ export const PageBreadcrumbs = () => {
       <Stack margin="s200 s400">
         <Tabs onChange={handleTabChange} tabs={tabs} selectedTab={activeTab} />
       </Stack>
-      {/*activeTab === "Example" && < /> */}
+      {activeTab === "Playground" && <PlaygroundBreadcrumbs />}
       {activeTab === "Code" && <CodeBreadcrumbs />}
     </>
   );


### PR DESCRIPTION
The Playground is implemented, allowing interactivity between the controls and the component to be documented `<Breadcrumbs />`.