### PR TITLE
should start with uppercase Stack component

### DIFF
--- a/src/pages/home/config/apps.config.tsx
+++ b/src/pages/home/config/apps.config.tsx
@@ -137,7 +137,7 @@ export const navItems = {
         },
         stack: {
           id: "stack",
-          label: "stack",
+          label: "Stack",
           path: "/stack",
           icon: <MdAccountBalanceWallet />,
         },


### PR DESCRIPTION
set the Stack option in the menu, so that it follows the uppercase standard.
giving a solution to the issue # 37