### PR TITLE
Adjust Padding Size in Main Class to Match Documentation

### DIFF
--- a/src/pages/Root/styles.ts
+++ b/src/pages/Root/styles.ts
@@ -12,7 +12,7 @@ const StyledRoot = styled.div`
 
 const StyledMain = styled.main`
   box-sizing: border-box;
-  padding: 32px 32px;
+  padding: 32px 64px;
 `;
 
 const StyledNavContainer = styled.div`


### PR DESCRIPTION
This pull request addresses the discrepancy in the padding size for the main class. Currently, the main class receives a padding of 32px, whereas in the Figma design it is specified as 32px 64px. This update adjusts the padding size to ensure consistency with the design documentation.