### PR TITLE
Include Icon for copy to clip-board on playground section

### DIFF
--- a/src/pages/Components/DynamicComponent/Tabs/Playground/index.tsx
+++ b/src/pages/Components/DynamicComponent/Tabs/Playground/index.tsx
@@ -17,6 +17,8 @@ import {
   SectionMessage,
 } from "@inubekit/sectionmessage";
 import { MdInfo } from "react-icons/md";
+import { Icon } from "@inubekit/icon";
+import { MdContentCopy } from "react-icons/md";
 
 interface IPlayground {
   component: any;
@@ -76,8 +78,15 @@ function Playground(props: IPlayground) {
       >
         <Stack direction="column" gap="32px">
           <Text type="headline" size="small" children="Installation" />
-          <StyledTag onClick={handleTagClick}>
+          <StyledTag>
             <Tag appearance="dark" label={installCommand} />
+            <Icon
+              appearance="primary"
+              icon={<MdContentCopy />}
+              spacing="compact"
+              variant="filled"
+              onClick={handleTagClick}
+            />
           </StyledTag>
         </Stack>
 

--- a/src/pages/Components/DynamicComponent/Tabs/Playground/styles.ts
+++ b/src/pages/Components/DynamicComponent/Tabs/Playground/styles.ts
@@ -1,15 +1,19 @@
 import styled from "styled-components";
+import { inube } from "@inubekit/foundations";
 
 const StyledTag = styled.div`
-  max-width: 200px;
-  & > div {
-    display: flex;
-    max-width: 200px;
-    max-height: 52px;
-    height: 100%;
-    align-items: center;
-    padding: 6px;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  max-width: 264px;
+  max-height: 52px;
+  height: 100%;
+  justify-content: space-between;
+  padding: 16px;
+  border-radius: 8px;
+  background-color: ${({ theme }) =>
+    theme.tag?.dark?.normal?.background?.color ||
+    inube.tag.dark.normal.background.color};
+  & > figure:hover {
     cursor: pointer;
   }
 `;


### PR DESCRIPTION
This PR introduces a new feature to the playground section by adding an icon for copying content to the clipboard. The inclusion of this icon aims to enhance user experience by providing an easy and convenient way for users to copy text or code snippets directly from the playground interface.