### PR TITLE
Adjust `<Text/>` when the appeareance is light on the playground

### DIFF
--- a/src/content/data/Text/Controller/Text.Controller.tsx
+++ b/src/content/data/Text/Controller/Text.Controller.tsx
@@ -1,0 +1,16 @@
+import { Text, IText } from "@inubekit/text";
+import { Stack } from "@inubekit/stack";
+import { StyledContainerText } from "./styles";
+
+const TextController = (props: IText) => {
+  const { appearance } = props;
+  return (
+    <Stack justifyContent="center" alignItems="center" height="150px">
+      <StyledContainerText isLightAppearance={appearance === "light"}>
+        <Text {...props} />
+      </StyledContainerText>
+    </Stack>
+  );
+};
+
+export { TextController };

--- a/src/content/data/Text/Controller/styles.ts
+++ b/src/content/data/Text/Controller/styles.ts
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+import { inube } from "@inubekit/foundations";
+
+interface StyledContainerTextProps {
+  isLightAppearance: boolean;
+}
+
+const StyledContainerText = styled.div<StyledContainerTextProps>`
+  background-color: ${({ theme, isLightAppearance }) =>
+    isLightAppearance
+      ? theme?.text?.dark?.content?.color?.regular ||
+        inube.text.dark.content.color.regular
+      : "unset"};
+`;
+
+export { StyledContainerText };

--- a/src/content/data/Text/index.ts
+++ b/src/content/data/Text/index.ts
@@ -1,6 +1,6 @@
-import { Text } from "@inubekit/text";
 import { inube } from "@inubekit/foundations";
 import { buildTokenDescriptions } from "../../tokens/buildTokenDescriptions";
+import { TextController } from "./Controller/Text.Controller";
 
 const textTokensConfig = {
   businessUnit: "inube",
@@ -20,7 +20,7 @@ const textTokensConfig = {
 const text = {
   description:
     "Component designed to specify the colors that the text receives within the application",
-  example: Text,
+  example: TextController,
   name: "Text",
   props: {
     children: "“The quick brown fox jumps over the lazy dog”",


### PR DESCRIPTION
This PR adjusts the appearance of the `<Text/>` component in the playground section when the light mode is enabled. The changes aim to improve readability and ensure a consistent visual experience in light mode.