### PR TITLE
adjust size of copy to clipboard section

### DIFF
--- a/src/pages/Components/DynamicComponent/Tabs/Playground/styles.ts
+++ b/src/pages/Components/DynamicComponent/Tabs/Playground/styles.ts
@@ -7,7 +7,8 @@ const StyledTag = styled.div`
   max-width: 264px;
   max-height: 52px;
   height: 100%;
-  justify-content: space-between;
+  width: fit-content;
+  gap: 16px;
   padding: 16px;
   border-radius: 8px;
   background-color: ${({ theme }) =>


### PR DESCRIPTION
This PR introduces a new feature to the playground section by adding an icon for copying content to the clipboard. The inclusion of this icon aims to enhance user experience by providing an easy and convenient way for users to copy text or code snippets directly from the playground interface.