### PR TITLE
When the user switches from one component to another, the tabs must restart their navigation

### DIFF
--- a/src/pages/Components/DynamicComponent/index.tsx
+++ b/src/pages/Components/DynamicComponent/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { Stack } from "@inubekit/stack";
 import { Tabs } from "@inube/design-system";
@@ -40,6 +40,10 @@ function DynamicComponent() {
   const location = useLocation();
   const component = location.pathname.split("/").pop();
 
+  useEffect(() => {
+    setActiveTab(tabs[0].id);
+  }, [component]);
+
   return (
     <>
       {component && (
@@ -64,13 +68,22 @@ function DynamicComponent() {
               {activeTab === "Playground" &&
                 component &&
                 components[component!] && (
-                  <Playground component={components[component!]} />
+                  <Playground
+                    key={`${component}-Playground`}
+                    component={components[component!]}
+                  />
                 )}
               {activeTab === "PropsAndTypes" && components[component!] && (
-                <PropsAndTypes component={components[component!]} />
+                <PropsAndTypes
+                  key={`${component}-PropsAndTypes`}
+                  component={components[component!]}
+                />
               )}
               {activeTab === "Theming" && components[component!] && (
-                <Theming component={components[component!]} />
+                <Theming
+                  key={`${component}-Theming`}
+                  component={components[component!]}
+                />
               )}
               {activeTab === "IssuesAndSuggestions" && <IssuesAndSuggestions />}
             </>

--- a/src/pages/Root/index.tsx
+++ b/src/pages/Root/index.tsx
@@ -31,15 +31,18 @@ function Root() {
         navigation={navigation}
         showUser={false}
       />
-      <StyledNavContainer>
-        <Grid
-          templateColumns={smallScreen ? "1fr" : "auto 1fr"}
-          alignContent="unset"
-        >
-          {!smallScreen && <Nav navigation={navigation as any} collapse />}
-          <StyledMain>{hasContent ? <Outlet /> : <Main />}</StyledMain>
-        </Grid>
-      </StyledNavContainer>
+
+      <Grid
+        templateColumns={smallScreen ? "1fr" : "auto 1fr"}
+        alignContent="unset"
+      >
+        {!smallScreen && (
+          <StyledNavContainer>
+            <Nav navigation={navigation as any} collapse />
+          </StyledNavContainer>
+        )}
+        <StyledMain>{hasContent ? <Outlet /> : <Main />}</StyledMain>
+      </Grid>
     </StyledRoot>
   );
 }

--- a/src/pages/Root/styles.ts
+++ b/src/pages/Root/styles.ts
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 
 const StyledRoot = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+
   & header {
     position: relative;
     z-index: 1;
@@ -13,41 +17,49 @@ const StyledRoot = styled.div`
 const StyledMain = styled.main`
   box-sizing: border-box;
   padding: 32px 64px;
+  flex-grow: 1;
+  height: calc(100vh - 53px);
+  overflow-y: auto;
 `;
 
 const StyledNavContainer = styled.div`
-  & > div > nav {
-    position: relative;
-    overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 53px);
+  overflow-y: auto;
+
+  & > nav {
+    flex-grow: 1;
+    overflow-y: auto;
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
     scroll-behavior: smooth;
     transition: overflow-y 0.3s ease-in-out;
+
+    & > div {
+      height: 100%;
+    }
   }
 
-  & > div > nav::-webkit-scrollbar {
+  & > nav::-webkit-scrollbar {
     width: 8px;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
   }
 
-  & > div > nav::-webkit-scrollbar-thumb {
+  & > nav::-webkit-scrollbar-thumb {
     background-color: rgba(0, 0, 0, 0.3);
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
     border-radius: 8px;
   }
 
-  & > div > nav:hover {
-    overflow-y: scroll;
-  }
-
-  & > div:hover > div::-webkit-scrollbar,
-  & > div:hover > div::-webkit-scrollbar-thumb {
+  & > nav:hover::-webkit-scrollbar,
+  & > nav:hover::-webkit-scrollbar-thumb {
     opacity: 1;
   }
 
-  & > div > div::-webkit-scrollbar-track {
+  & > nav::-webkit-scrollbar-track {
     background: transparent;
   }
 `;


### PR DESCRIPTION
The current implementation retains the tab navigation state even when the user switches from one component to another, which leads to an undesired user experience. This adjustment ensures that each time a user switches components, the tabs restart their navigation, providing a consistent and expected behavior.