### PR TITLE
Remove unnecessary padding left on install-command

### DIFF
--- a/src/pages/Components/DynamicComponent/styles.ts
+++ b/src/pages/Components/DynamicComponent/styles.ts
@@ -9,7 +9,7 @@ const StyledTag = styled.div`
   height: 100%;
   width: fit-content;
   gap: 16px;
-  padding: 16px;
+  padding: 16px 0px;
   border-radius: 8px;
   & > figure:hover {
     cursor: pointer;


### PR DESCRIPTION
This PR addresses the issue of unnecessary padding left on the install-command component. The padding was causing layout inconsistencies and affecting the overall UI alignment. The change removes the extra padding, resulting in a more streamlined and consistent appearance across the interface. No functionality is affected by this change; it purely improves the visual layout. Please review and merge if approved.